### PR TITLE
Fixed bug that doesn't recognize any actions in `add_queue_permission()`

### DIFF
--- a/R/permissions.r
+++ b/R/permissions.r
@@ -27,7 +27,7 @@ add_queue_permission <- function(queue, label, principal, action, query = NULL, 
         }
     }
     v <- c("*", "SendMessage", "ReceiveMessage", "DeleteMessage", "ChangeMessageVisibility", "GetQueueAttributes", "GetQueueUrl")
-    if (!any(action) %in% v) {
+    if (!any(action %in% v)) {
         stop("Unrecogized 'action':", paste0(action[!action %in% v], collapse = ", "))
     }
     a <- paste0("ActionName.", seq_along(action))


### PR DESCRIPTION
Please ensure the following before submitting a PR:

 - [ ] if suggesting code changes or improvements, [open an issue](https://github.com/cloudyr/aws.sqs/issues/new) first
 - [ ] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/cloudyr/aws.sqs/blob/master/DESCRIPTION)
 - [ ] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/cloudyr/aws.sqs/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [ ] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [ ] add code or new test files to [`/tests`](https://github.com/cloudyr/aws.sqs/tree/master/tests/testthat) for any new functionality or bug fix
 - [ ] make sure `R CMD check` runs without error before submitting the PR

